### PR TITLE
`begin` was indexed on newline

### DIFF
--- a/src/main/java/org/apache/hadoop/mapreduce/lib/input/CSVNLineInputFormat.java
+++ b/src/main/java/org/apache/hadoop/mapreduce/lib/input/CSVNLineInputFormat.java
@@ -124,7 +124,7 @@ public class CSVNLineInputFormat extends FileInputFormat<LongWritable, List<Text
 					if (begin == 0) {
 						splits.add(new FileSplit(fileName, begin, length - 1, new String[] {}));
 					} else {
-						splits.add(new FileSplit(fileName, begin - 1, length, new String[] {}));
+						splits.add(new FileSplit(fileName, begin, length, new String[] {}));
 					}
 					begin += length;
 					length = 0;


### PR DESCRIPTION
`begin -1` was causing the start index of a split to reside on the newline char `\n`. It was causing my mappers to receive an extra map that contained a `List<Text>` of length 1. Changing this line to `begin` starts the split on the character after the newline and now my mapper gets the correct number of records.